### PR TITLE
Allow setting of server and livereload to different ports

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -15,6 +15,7 @@
 	var del         = require('del');
 	var merge       = require('merge-stream');
 	var runseq      = require('run-sequence');
+	var argv  		= require('yargs').argv;
 
 	var BOWER       = 'bower_components/';
 	var PUBLIC      = 'public/';
@@ -156,9 +157,10 @@
 ///	UTILITY FUNCTIONS /////////////////////////////////////////////////////////
 ///	
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Start up the server module
+/*/ Start up the server module, passing yargs.argv object, which will be
+	used as a configuration object by startServer
 /*/	function runServer() {
-		serverInstance = server1401.startServer();
+		serverInstance = server1401.startServer( argv );
 		server1401.startLiveReload();
 		// if changing watch path, make sure to change copy paths in tasks
 		gulp.watch(ASSETS+'modules/**', function ( event ) {

--- a/build/package.json
+++ b/build/package.json
@@ -33,6 +33,7 @@
     "gulp-express": "^0.3.5",
     "gulp-util": "^3.0.7",
     "merge-stream": "^1.0.0",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^1.1.5",
+    "yargs": "^4.7.1"
   }
 }

--- a/build/server/1401.js
+++ b/build/server/1401.js
@@ -23,6 +23,7 @@
 	var tinylr;	// set by startLiveReload
 	var app; 	// set by startServer
 	var server;	// set by startServer
+	var config; // save configuration object from startServer()
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,19 +45,22 @@
 /*/ config is an object. It will be created if it doesn't exist. This is called
 	by gulpfile.js's runServer() function, which passes a yargs.argv object that
 	should be compatible with this code.
-/*/	function startServer ( config ) {
+/*/	function startServer ( cfg ) {
 
 		// close server if it's already running
 		var server_restart = (server) ? true : false;
-		if (server) {
+		if (server_restart) {
 			server.close();
 		}
 
-		// set defaults
-		config = config || {};
+		// initialize config from either passed value or as new object
+		config = cfg || {};
+		// set default values if not defined
 		config.liveReload = config.liveReload || {};
 		config.liveReload.enabled = config.liveReload.enabled || true;
-		config.isOptimize = config.isOptimize!==undefined;
+		// force optimize false always to use requirejs
+		config.isOptimize = false; // was config.isOptimize!==undefined;
+		config.liveReloadPort = config.liveport || LIVERELOAD_PORT;
 		config.port = config.port || EXPRESS_PORT;
 
 		// instantiate express app
@@ -88,7 +92,7 @@
 		var router = express.Router();
 		router.get('/', function(req, res) {
 			var fullURL = req.protocol+"://";
-			fullURL += req.hostname+':'+LIVERELOAD_PORT;
+			fullURL += req.hostname+':'+config.liveReloadPort;
 			fullURL += '/livereload.js';
 			res.render('index', {
 				reload: 	config.liveReload,
@@ -115,8 +119,9 @@
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	function startLiveReload() {
 		tinylr = require('tiny-lr')();
-		tinylr.listen( LIVERELOAD_PORT, function () {
-			console.log(DP,'Live reload of assets is enabled',DP);
+		tinylr.listen( config.liveReloadPort, function () {
+			console.log(DP,'Live reload of assets is enabled, (port',
+				config.liveReloadPort+')',DP);
 		});
 	} // startLiveReload
 
@@ -131,7 +136,7 @@
 			}
 		});
 		console.log(FP,'reload:',fileName);
-		startServer();
+		startServer(config);
 	} // notifyLiveReload
 
 

--- a/build/server/1401.js
+++ b/build/server/1401.js
@@ -41,7 +41,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-	function startServer ( config ) {
+/*/ config is an object. It will be created if it doesn't exist. This is called
+	by gulpfile.js's runServer() function, which passes a yargs.argv object that
+	should be compatible with this code.
+/*/	function startServer ( config ) {
 
 		// close server if it's already running
 		var server_restart = (server) ? true : false;
@@ -54,6 +57,7 @@
 		config.liveReload = config.liveReload || {};
 		config.liveReload.enabled = config.liveReload.enabled || true;
 		config.isOptimize = config.isOptimize!==undefined;
+		config.port = config.port || EXPRESS_PORT;
 
 		// instantiate express app
 		app = express();
@@ -62,7 +66,7 @@
 		app.set('views', VIEWS_PATH);
 		app.engine(VIEWS_EXT, engines[VIEWS_COMPILER]);
 		app.set('view engine', VIEWS_EXT);
-		app.set('port', process.env.PORT || EXPRESS_PORT || 3000);
+		app.set('port', config.port || 3000);
 
 		// middleware declarations
 		app.use(compression());


### PR DESCRIPTION
Previously, the Express server always listened to port 3000, and used port 35729 for LiveReload detection. This meant that only one 1401 / 1401A1 system could run at one time due to port conflicts.

Two new parameters are added to the `gulp` command:
* `--port NNNN` will set the ExpressJS port (default is port 3000)
* `--liveport NNNN` will set the LiveReload port (default is 35729)
