### PR TITLE
Add Fixed, Scaled, and Fluid Presets for ScreenLayout

### DIFF
--- a/build/assets/modules/1401-games/_blank/_appshell.html
+++ b/build/assets/modules/1401-games/_blank/_appshell.html
@@ -1,30 +1,5 @@
-<style scoped>
-	#display {
-        margin: 20px 20px 0 20px;
-	}
-	#debug {
-		font-size: 12px;
-		margin-top: 4px;
-		overflow-y: scroll;
-		line-height: 1.5em;
-		height: 9em;
-		background-color: #f0f0f0;
-	}
-	#status span {
-		font-size: smaller;
-	}
-</style>
-
 <div id="display">
-	<p>
-		<strong data-bind="text: displayName"></strong>  - <span data-bind="text: description"></span>
+	<p style="margin:20px 40px">
+		SCREEN INITIALIZE
 	</p>
-	<div id="container">
-		<div id="overlay"></div>
-	</div>
-	<div id="debug">
-	</div>
-	<div id="status">
-		<span>open javascript console to see debug messages Control-Shift-J (Window) or Command-Option-J (Mac)</span>
-	</div>
 </div>

--- a/build/assets/modules/1401-games/_blank/game-run.js
+++ b/build/assets/modules/1401-games/_blank/game-run.js
@@ -89,7 +89,8 @@ define ([
 			worldUnits 		: 768			// world units to fit in shortest dim
 		};
 		SCREEN.CreateLayout( cfg );
-
+		SCREEN.SetInfo('<h4>PlanTitle</h4><p>Starter tempalte</p>');
+		SCREEN.SetDisplayMargin(20);
 	}
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/	Construct() happens after Iniitialize is complete for all SYSLOOP modules.

--- a/build/assets/modules/1401-games/_blank/game-run.js
+++ b/build/assets/modules/1401-games/_blank/game-run.js
@@ -4,12 +4,16 @@ define ([
 	'1401/objects/sysloop',
 	'1401/system/renderer',
 	'1401/system/screen',
+	'1401/system/visualfactory',
+	'1401/system/piecefactory',
 	SYS1401.LocalPath('example-component')
 ], function ( 
 	SETTINGS,
 	SYSLOOP,
 	RENDERER,
 	SCREEN,
+	VISUALFACTORY,
+	PIECEFACTORY,
 	COMPONENT
 ) {
 
@@ -48,6 +52,7 @@ define ([
 	// add handlers as needed
 	MAIN.SetHandler( 'Connect'		, API_HandleConnect );
 	MAIN.SetHandler( 'Initialize'	, API_HandleInitialize );
+	MAIN.SetHandler( 'Construct'	, API_HandleConstruct );
 	MAIN.SetHandler( 'GameStep'		, API_GameStep );
 
 
@@ -65,7 +70,6 @@ define ([
 	opportunity to save a reference if it needs to access the HTML
 	layer of code (knockout variables, for example)
 /*/	function API_HandleConnect ( viewModel ) {
-
 		console.log("MAIN: Initializing!");
 
 		// save the viewmodel if we want it later
@@ -87,7 +91,25 @@ define ([
 		SCREEN.CreateLayout( cfg );
 
 	}
-
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	Construct() happens after Iniitialize is complete for all SYSLOOP modules.
+/*/	function API_HandleConstruct () {
+		/* make crixa ship */
+		var shipSprite = VISUALFACTORY.MakeDefaultSprite();
+		shipSprite.SetZoom(1.0);
+		RENDERER.AddWorldVisual(shipSprite);
+		var seq = {
+			grid: { columns:2, rows:1, stacked:true },
+			sequences: [
+				{ name: 'flicker', framecount: 2, fps:4 }
+			]
+		};
+		shipSprite.DefineSequences(SETTINGS.AssetPath('../demo/resources/crixa.png'),seq);
+		// shipSprite.PlaySequence("flicker");
+		crixa = PIECEFACTORY.NewMovingPiece("crixa");
+		crixa.SetVisual(shipSprite);
+		crixa.SetPositionXYZ(0,0,0);
+	}
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/	MasterStep is a method reserved for the 'master game loop', which is
 	established by the SYSLOOP.InitializeGame() call. MasterStep() is 

--- a/build/assets/modules/1401-games/_blank/game-run.js
+++ b/build/assets/modules/1401-games/_blank/game-run.js
@@ -3,11 +3,13 @@ define ([
 	'1401/settings',
 	'1401/objects/sysloop',
 	'1401/system/renderer',
+	'1401/system/screen',
 	SYS1401.LocalPath('example-component')
 ], function ( 
 	SETTINGS,
 	SYSLOOP,
 	RENDERER,
+	SCREEN,
 	COMPONENT
 ) {
 
@@ -44,8 +46,9 @@ define ([
 	var MAIN = SYSLOOP.InitializeGame('Game-Run');
 
 	// add handlers as needed
-	MAIN.SetHandler( 'Connect', API_HandleConnect );
-	MAIN.SetHandler( 'GameStep', API_GameStep );
+	MAIN.SetHandler( 'Connect'		, API_HandleConnect );
+	MAIN.SetHandler( 'Initialize'	, API_HandleInitialize );
+	MAIN.SetHandler( 'GameStep'		, API_GameStep );
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -67,20 +70,22 @@ define ([
 
 		// save the viewmodel if we want it later
 		m_viewmodel = viewModel;
+	}
 
-		// initialize the renderer
-		var parm = {
-			attachTo: '#container',		// WebGL attaches to this
-			renderWidth: 768,			// width of render context
-			renderHeight: 768,			// height of render context
-			worldUnits: 768				// world units to fit in shortest dim
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	Initialize() happens after Connect() is complete for all SYSLOOP modules.
+/*/	function API_HandleInitialize () {
+
+		// instead of initializing renderer directly,
+		// use SCREEN which will initialize it for us
+		var cfg = {
+			mode 			: 'scaled',		// layout mode
+			renderWidth 	: 768,			// width of render context
+			renderHeight 	: 768,			// height of render context
+			worldUnits 		: 768			// world units to fit in shortest dim
 		};
-		RENDERER.Initialize ( parm );
-		RENDERER.AutoRender();
+		SCREEN.CreateLayout( cfg );
 
-		// size the width of the debug window
-		$('#debug').css('width',parm.renderWidth+'px');
-		// debug.js defines window.DBG_Out() which writes to #debug
 	}
 
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/assets/modules/1401-games/_blank/game-run.js
+++ b/build/assets/modules/1401-games/_blank/game-run.js
@@ -84,9 +84,9 @@ define ([
 		// use SCREEN which will initialize it for us
 		var cfg = {
 			mode 			: 'scaled',		// layout mode
-			renderWidth 	: 768,			// width of render context
-			renderHeight 	: 768,			// height of render context
-			worldUnits 		: 768			// world units to fit in shortest dim
+			renderWidth 	: 768,			// width of viewport
+			renderHeight 	: 768,			// height of viewport
+			worldUnits 		: 768			// world units visible in viewport
 		};
 		SCREEN.CreateLayout( cfg );
 		SCREEN.SetInfo('<h4>PlanTitle</h4><p>Starter tempalte</p>');

--- a/build/assets/modules/1401-games/demo/_appshell.html
+++ b/build/assets/modules/1401-games/demo/_appshell.html
@@ -16,15 +16,5 @@
 </style>
 
 <div id="display">
-	<p>
-		<strong data-bind="text: displayName"></strong>  - <span data-bind="text: description"></span>
-	</p>
-	<div id="container">
-		<div id="overlay"></div>
-	</div>
-	<div id="debug">
-	</div>
-	<div id="status">
-		<span>open javascript console to see debug messages Control-Shift-J (Window) or Command-Option-J (Mac)</span>
-	</div>
+	LOADING
 </div>

--- a/build/assets/modules/1401-games/demo/game-run.js
+++ b/build/assets/modules/1401-games/demo/game-run.js
@@ -93,10 +93,10 @@ define ([
 		// instead of initializing renderer directly,
 		// use SCREEN which will initialize it for us
 		var cfg = {
-			mode 			: 'fluid',		// layout mode (fixed default)
-			renderWidth 	: 768,			// width of render context
-			renderHeight 	: 768,			// height of render context
-			worldUnits 		: 768			// world units to fit in shortest dim
+			mode 			: 'fluid',		// layout mode
+			renderWidth 	: 768,			// width of viewport
+			renderHeight 	: 768,			// height of viewport
+			worldUnits 		: 768			// world units visible in viewport
 		};
 		SCREEN.CreateLayout( cfg );
 

--- a/build/assets/modules/1401-games/demo/game-run.js
+++ b/build/assets/modules/1401-games/demo/game-run.js
@@ -93,7 +93,7 @@ define ([
 		// instead of initializing renderer directly,
 		// use SCREEN which will initialize it for us
 		var cfg = {
-			mode 			: 'fluid',		// layout mode
+			mode 			: 'fluid',		// layout mode (fixed default)
 			renderWidth 	: 768,			// width of render context
 			renderHeight 	: 768,			// height of render context
 			worldUnits 		: 768			// world units to fit in shortest dim

--- a/build/assets/modules/1401-games/demo/game-run.js
+++ b/build/assets/modules/1401-games/demo/game-run.js
@@ -9,6 +9,7 @@ define ([
 	'1401/settings',
 	'1401/objects/sysloop',
 	'1401/system/renderer',
+	'1401/system/screen',
 /*** UNCOMMENT ONE TEST *****************************************************/
 //	SYS1401.LocalPath('tests/001-gameloop')
 //	SYS1401.LocalPath('tests/002-stars-finite')
@@ -18,12 +19,14 @@ define ([
 //	SYS1401.LocalPath('tests/006-btree-factory')
 //	SYS1401.LocalPath('tests/007-loadassets')
 //	SYS1401.LocalPath('tests/008-timer')
-	SYS1401.LocalPath('tests/009-ship-bullets')
+//	SYS1401.LocalPath('tests/009-ship-bullets')
+	SYS1401.LocalPath('tests/010-screen')
 ], function ( 
 	DBG,
 	SETTINGS,
 	SYSLOOP,
 	RENDERER,
+	SCREEN,
 	TEST
 ) {
 
@@ -60,8 +63,9 @@ define ([
 	var MAIN = SYSLOOP.InitializeGame('Game-Main');
 
 	// add handlers as needed
-	MAIN.SetHandler( 'Connect', API_HandleConnect );
-	MAIN.SetHandler( 'GameStep', API_GameStep );
+	MAIN.SetHandler( 'Connect'		, API_HandleConnect );
+	MAIN.SetHandler( 'Initialize'	, API_HandleInitialize );
+	MAIN.SetHandler( 'GameStep'		, API_GameStep );
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -80,19 +84,22 @@ define ([
 /*/	function API_HandleConnect ( viewModel ) {
 
 		m_viewmodel = viewModel;
-		console.log("MAIN: Initializing!");
-		var parm = {
-			attachTo: '#container',		// WebGL attaches to this
-			renderWidth: 768,			// width of render context
-			renderHeight: 768,			// height of render context
-			worldUnits: 768				// world units to fit in shortest dim
-		};
-		RENDERER.Initialize ( parm );
-		RENDERER.AutoRender();
+	}
 
-		// size the width of the debug window
-		$('#debug').css('width',parm.renderWidth+'px');
-		// debug.js defines window.DBG_Out() which writes to #debug
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	Initialize() happens after Connect() is complete for all SYSLOOP modules.
+/*/	function API_HandleInitialize () {
+
+		// instead of initializing renderer directly,
+		// use SCREEN which will initialize it for us
+		var cfg = {
+			mode 			: 'fluid',		// layout mode
+			renderWidth 	: 768,			// width of render context
+			renderHeight 	: 768,			// height of render context
+			worldUnits 		: 768			// world units to fit in shortest dim
+		};
+		SCREEN.CreateLayout( cfg );
+
 	}
 
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/assets/modules/1401-games/demo/tests/010-screen.js
+++ b/build/assets/modules/1401-games/demo/tests/010-screen.js
@@ -1,0 +1,248 @@
+/* demo/test/010-screen.js */
+define ([
+	'keypress',
+	'physicsjs',
+	'howler',
+	'1401/objects/sysloop',
+	'1401/settings',
+	'1401/system/renderer',
+	'1401/system/visualfactory',
+	'1401/system/piecefactory',
+	'1401-games/demo/modules/controls'
+], function ( 
+	KEY,
+	PHYSICS,
+	HOWLER,
+	SYSLOOP,
+	SETTINGS,
+	RENDERER,
+	VISUALFACTORY,
+	PIECEFACTORY,
+	SHIPCONTROLS
+) {
+
+	var DBGOUT = true;
+
+///////////////////////////////////////////////////////////////////////////////
+/**	SUBMODULE TEST 010 *******************************************************\
+
+	Based on 009, which was based on 004
+	010 puts 009 into a new SCREEN module
+
+///////////////////////////////////////////////////////////////////////////////
+/** MODULE DECLARATION *******************************************************/
+
+	var MOD = SYSLOOP.New("Test10");
+
+	MOD.EnableUpdate( true );
+	MOD.EnableInput( true );
+
+	MOD.SetHandler( 'Construct', m_Construct );
+	MOD.SetHandler( 'Start', m_Start );
+	MOD.SetHandler( 'GetInput', m_GetInput);
+	MOD.SetHandler( 'Update', m_Update);
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** PRIVATE VARS *************************************************************/
+
+	var crixa;				// ship piece
+	var crixa_inputs;		// encoded controller inputs
+	var starfields = [];	// parallax starfield layersey
+
+	var snd_pewpew;			// sound instance (howler.js)
+	var snd_music;
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** MODULE HANDLER FUNCTIONS *************************************************/
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	function m_Construct() {
+
+			var i, platform;
+
+			var cam = RENDERER.Viewport().WorldCam3D();
+			var z = cam.position.z;
+			var fog = new THREE.Fog(0x000000,z-100,z+50);
+			RENDERER.SetWorldVisualFog(fog);
+
+			/* add lights so mesh colors show */
+			var ambientLight = new THREE.AmbientLight(0x222222);
+			RENDERER.AddWorldVisual(ambientLight);
+
+			var directionalLight = new THREE.DirectionalLight(0xffffff);
+			directionalLight.position.set(1, 1, 1).normalize();
+			RENDERER.AddWorldVisual(directionalLight);
+
+			/* make starfield */
+			var starBright = [ 
+				new THREE.Color( 1.0, 1.0, 1.0 ),
+				new THREE.Color( 0.5, 0.5, 0.7 ),
+				new THREE.Color( 0.3, 0.3, 0.5 )
+			];
+			var starSpec = {
+				parallax: 1
+			};		
+			starfields = [];
+			for (i=0;i<3;i++) {
+				starSpec.color=starBright[i];
+				var sf = VISUALFACTORY.MakeStarField( starSpec );
+				starSpec.parallax *= 0.5;
+				sf.position.set(0,0,-100-i);
+				RENDERER.AddBackgroundVisual(sf);
+				starfields.push(sf);
+			}
+
+			/* make crixa ship */
+			var shipSprite = VISUALFACTORY.MakeDefaultSprite();
+			shipSprite.SetZoom(1.0);
+			RENDERER.AddWorldVisual(shipSprite);
+			var seq = {
+				grid: { columns:2, rows:1, stacked:true },
+				sequences: [
+					{ name: 'flicker', framecount: 2, fps:4 }
+				]
+			};
+			shipSprite.DefineSequences(SETTINGS.AssetPath('../demo/resources/crixa.png'),seq);
+			// shipSprite.PlaySequence("flicker");
+			crixa = PIECEFACTORY.NewMovingPiece("crixa");
+			crixa.SetVisual(shipSprite);
+			crixa.SetPositionXYZ(0,0,0);
+
+			// add extra shooting command
+			crixa.Shoot = function ( bool ) {
+				if (bool) {
+					// snd_pewpew.play();
+					console.log(this.name,"shoot bullet");
+					// create a new bullet 
+					var bp = PIECEFACTORY.NewMovingPiece();
+					bp.body.radius = bp.body.geometry.radius = 2;
+					bp.body.mass = 0.1;
+					// var bvis = VISUALFACTORY.MakeDefaultSprite();
+					var sprPath = SETTINGS.AssetPath('../demo/resources/bullet32-blue.png');
+					var bvis = VISUALFACTORY.MakeStaticSprite( sprPath, function () {
+						bvis.SetZoom(1);
+					});
+					bp.SetVisual(bvis);	
+					RENDERER.AddWorldVisual(bvis);
+
+					// this.state.pos (Physics.vector) The position vector.
+					// this.state.vel (Physics.vector) The velocity vector.
+					// this.state.acc (Physics.vector) The acceleration vector.
+					// this.state.angular.pos (Number) The angular position (in radians, positive is clockwise starting along the x axis)
+					// this.state.angular.vel (Number) The angular velocity
+					// this.state.angular.acc (Number) The angular acceleration					
+					var vel = PHYSICS.vector(0.4, 0);
+					vel.rotate(this.body.state.angular.pos);
+					vel.vadd(this.body.state.vel);
+					bp.body.state.vel = vel;
+
+					bp.body.state.angular.pos = this.body.state.angular.pos;
+					var hardpoint = PHYSICS.vector(15,0);
+					hardpoint.rotate(this.body.state.angular.pos);
+					hardpoint.vadd(this.body.state.pos);
+					bp.body.state.pos = hardpoint;
+
+					// tag bullet
+					bp.body.isBullet = true;
+				}
+			};
+
+			// demonstration of texture validity
+			var textureLoaded = crixa.Visual().TextureIsLoaded();
+			console.log("SHIP TEXTURE LOADED TEST OK?",textureLoaded);
+			if (textureLoaded) {
+				console.log(". spritesheet dim",crixa.Visual().TextureDimensions());
+				console.log(". sprite dim",crixa.Visual().SpriteDimensions());
+			} else {
+				console.log(".. note textures load asynchronously, so the dimensions are not available yet...");
+				console.log(".. sprite class handles this automatically so you don't have to.");
+			}
+
+			// make sprites
+			for (i=0;i<3;i++) {
+				platform = VISUALFACTORY.MakeStaticSprite(
+					SETTINGS.AssetPath('../demo/resources/teleport.png'),
+					do_nothing
+				);
+				platform.SetZoom(1.0);
+				platform.position.set(0,100,100-(i*50));
+				RENDERER.AddWorldVisual(platform);
+			}
+
+			for (i=0;i<3;i++) {
+				platform = VISUALFACTORY.MakeStaticSprite(
+					SETTINGS.AssetPath('../demo/resources/teleport.png'),
+					do_nothing
+				);
+				platform.position.set(0,-125,100-(i*50));
+				platform.SetZoom(1.25);
+				RENDERER.AddWorldVisual(platform);
+			}
+
+			function do_nothing () {}
+
+			// load sound
+			var sfx = SETTINGS.AssetPath('../demo/resources/pewpew.ogg');
+			snd_pewpew = new Howl({
+				urls: [sfx]
+			});
+
+	}
+
+///	HEAP-SAVING PRE-ALLOCATED VARIABLES /////////////////////////////////////
+
+	var x, rot, vp, layers, i, sf;
+	var cin;
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	function m_Start() {
+		RENDERER.SelectWorld3D();
+		SHIPCONTROLS.BindKeys();
+
+		window.DBG_Out( "TEST 10 <b>Screen Modes!</b>" );
+		window.DBG_Out( "<tt>game-main include: 1401-games/demo/tests/010</tt>" );
+		window.DBG_Out( "Use WASDQE to move. SPACE brakes. C fires." );
+	}	
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	function m_GetInput ( interval_ms ) {
+		cin = crixa_inputs = SHIPCONTROLS.GetInput();
+		if (!!crixa_inputs.forward_acc) {
+			crixa.Visual().GoSequence("flicker",1);
+		} else {
+			crixa.Visual().GoSequence("flicker",0);
+		}
+		crixa.Accelerate(cin.forward_acc,cin.side_acc);
+		crixa.Brake(crixa_inputs.brake_lin);
+		crixa.AccelerateRotation(cin.rot_acc);
+		crixa.BrakeRotation(crixa_inputs.brake_rot);
+		crixa.Shoot(SHIPCONTROLS.Fire());
+	}
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	var counter = 0;
+	var dx = 3;
+	function m_Update ( interval_ms ) {
+
+		vp = RENDERER.Viewport();
+		vp.Track(crixa.Position());
+
+
+		/* rotate stars */	
+		layers = starfields.length;
+		for (i=0;i<starfields.length;i++){
+			sf = starfields[i];
+			sf.Track(crixa.Position());
+		}
+
+		counter += interval_ms;
+	}
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** RETURN MODULE DEFINITION FOR REQUIREJS ***********************************/
+	return MOD;
+
+});

--- a/build/assets/modules/1401-games/demo/tests/010-screen.js
+++ b/build/assets/modules/1401-games/demo/tests/010-screen.js
@@ -62,6 +62,7 @@ define ([
 
 			var i, platform;
 
+			RENDERER.SelectWorld3D();
 			var cam = RENDERER.Viewport().WorldCam3D();
 			var z = cam.position.z;
 			var fog = new THREE.Fog(0x000000,z-100,z+50);
@@ -198,7 +199,6 @@ define ([
 
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	function m_Start() {
-		RENDERER.SelectWorld3D();
 		SHIPCONTROLS.BindKeys();
 
 		window.DBG_Out( "TEST 10 <b>Screen Modes!</b>" );

--- a/build/assets/modules/1401/objects/viewport.js
+++ b/build/assets/modules/1401/objects/viewport.js
@@ -51,28 +51,35 @@ define ([
 		this.camSCREEN 		= null;		// screen (pixel coords)
 		// mouseraycasting
 		this.pickers 		= null;		// subscribes to mouse click events
+		// hacky access to constructor types
+		this.TYPE 			= Viewport;
 	}
 	Viewport.MODE_FIXED 	= 'fixed';
-	Viewport.MODE_SCALED 	= 'scale';
+	Viewport.MODE_SCALED 	= 'scaled';
 	Viewport.MODE_FLUID		= 'fluid';
 
 ///	INITIALIZATION ///////////////////////////////////////////////////////////
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Step 1. Initialize the WebGL surface and size containers exactly
-	Viewport.method('InitializeRenderer', function ( mode, width, height, containerId ) {
+	Viewport.method('InitializeRenderer', function ( width, height, containerId ) {
 		if (this.webGL) {
 			console.error("Renderer already initialized");
 			return;
 		}
-		if (!(mode && width && height && containerId)) {
-			console.error("Call InitializeRenderer() with mode, cwidth, cheight, containerId");
+		if (!(width && height && containerId)) {
+			console.error("Call InitializeRenderer() with cwidth, cheight, containerId");
 			return;
 		}
+		// check format of containerId string
 		if (typeof containerId !== 'string') {
 			console.error("Provide a valid selector");
 			return;
+		} 
+		if (containerId.charAt(0)!=='#') {
+			containerId = '#'+containerId;
 		}
+
 		var $container = $(containerId);
 		if (!$container) {
 			console.error("container",containerId,"does not exist");
@@ -118,6 +125,7 @@ define ([
 		/* size the webgl canvas to width, height in pixels */
 
 		window.SYS1401.glSize = function (w,h) {
+			instance.SetDimensions(w,h);
 			var CAMWORLD = window.SYS1401.CAMWORLD;
 			var WEBGL 	= window.SYS1401.WEBGL;
 			if (typeof w=='undefined') {
@@ -358,7 +366,6 @@ define ([
 		return d;
 
 	}
-
 
 
 

--- a/build/assets/modules/1401/system/debug.js
+++ b/build/assets/modules/1401/system/debug.js
@@ -1,6 +1,8 @@
 /* debug.js */
 define ([
+	'1401/system/screen'	
 ], function ( 
+	SCREEN
 ) {
 
 	var DBGOUT = true;
@@ -18,7 +20,6 @@ define ([
 	API.name = "debug";
 
 	var m_watching = {};
-	var m_debug_selector = '#debug';
 
 
 ///	INSPECTION ROUTINES //////////////////////////////////////////////////////
@@ -166,7 +167,7 @@ define ([
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/	Debugger window text output
 /*/	function m_DebugOut ( msg, escape_msg, selector ) {
-		selector = selector || m_debug_selector;
+		selector = selector || SCREEN.Debug;
 		var $dbg = $(selector);
 		if (Object.prototype.toString.call(e)==='[object Array]') {
 			$dbg = e[0];		// get first matching element

--- a/build/assets/modules/1401/system/renderer.js
+++ b/build/assets/modules/1401/system/renderer.js
@@ -51,13 +51,11 @@ define ([
 	worldUnits is the number of worldUnits to fit into the pixel viewport
 	crossOrigin is to allow non-server media assets to load
 /*/	API.Initialize = function ( parm ) {
-
 		// order of initialization is important
 		VIEWPORT.InitializeRenderer(
-			parm.displayMode || 'fixed',
 			parm.renderWidth,
 			parm.renderHeight,
-			parm.attachTo
+			parm.attachId
 		);
 
 		// using the renderWidth,Height as a 

--- a/build/assets/modules/1401/system/renderer.js
+++ b/build/assets/modules/1401/system/renderer.js
@@ -46,16 +46,23 @@ define ([
 ///	RENDER INIT & CONTROL ////////////////////////////////////////////////////
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/	Initialize Rendersystem 
+	displayMode is fixed, scaled, or fluid
+	renderWidth, renderHeight, attachTo are required
+	worldUnits is the number of worldUnits to fit into the pixel viewport
+	crossOrigin is to allow non-server media assets to load
 /*/	API.Initialize = function ( parm ) {
 
 		// order of initialization is important
 		VIEWPORT.InitializeRenderer(
+			parm.displayMode || 'fixed',
 			parm.renderWidth,
 			parm.renderHeight,
 			parm.attachTo
 		);
-		VIEWPORT.InitializeWorld(
-			parm.worldUnits
+
+		// using the renderWidth,Height as a 
+		VIEWPORT.SizeWorldToViewport(
+			parm.worldUnits || Math.min(parm.renderWidth, parm.renderHeight)
 		);
 		VIEWPORT.InitializeCameras();
 
@@ -236,7 +243,10 @@ define ([
 	API.Viewport = function () {
 		return VIEWPORT;
 	};
-
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	API.Resize = function ( w, h ) {
+		window.SYS1401.glSize(w,h);
+	};
 
 
 ///	BACKGROUND IMAGE /////////////////////////////////////////////////////////

--- a/build/assets/modules/1401/system/screen.js
+++ b/build/assets/modules/1401/system/screen.js
@@ -1,0 +1,299 @@
+/* screen */
+define ( [
+	'knockout',
+	'1401/objects/sysloop',
+	'1401/settings',
+	'1401/system/renderer',
+	'1401/objects/viewport'
+], function (
+	KO,
+	SYSLOOP,
+	SETTINGS,
+	RENDERER,
+	VIEWPORT
+) {
+
+///////////////////////////////////////////////////////////////////////////////
+/**	SCREEN *******************************************************************\
+
+	The SCREEN module manages the Bootstrap3-based HTML aspects of the user
+	interface. It supersedes UIBIND and the step/common/lib controls systems.
+
+	The screen-managed shell is all placed in a div defined by m_root_id,
+	which is completely emptied before new div elements are added. The CSS
+	is added programmatically.
+
+	LAYOUT
+
+	  div#display
+        div#renderer
+          div#overlay
+          webgl-canvas
+        div#dbg1401
+        div#nfo1401
+
+	LAYOUT RULES
+
+	FIXED 	- #renderer drawn upper left of #display, 1:1 pixel
+	SCALED 	- #renderer canvas is scaled to fit browser window
+	FLUID 	- #renderer is 1:1 pixels but is resized
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** PRIVATE SYSTEM VARIABLES *************************************************/
+
+	var m_root_id 		= 'display';	// id of parent div
+	var m_renderer_id	= 'renderer';	// id of renderer div
+	var m_root 			= null;			// jquery object for root
+	var m_cfg 			= null;			// remember configuration
+	var m_resize_timer	= null;			// screen resizing delay
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** SYSLOOP API **************************************************************/
+
+	var SCREEN 			= SYSLOOP.New('SCREEN');
+		SCREEN.Main 	= null;			// main renderer area
+		SCREEN.Overlay 	= null;			// html over Main
+		SCREEN.CPanel 	= null;			// control panel
+		SCREEN.Debug 	= null;			// debug area
+		SCREEN.Info 	= null;			// informational area
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	grab handles to all main elements of the screen.
+/*/	SCREEN.SetHandler( 'Connect', function () {
+//		var root = document.getElementById('sys1401');
+		var id = m_root_id;
+		var root = document.getElementById(id);
+		if (!root) {
+			console.warn("SCREEN requires div #"+id,"element");
+			return;
+		} 
+		console.log("FYI, SCREEN is overwriting contents of",id);
+		// define main areas
+		m_root = root = $(root);
+		root.empty();
+		root.append( '<div id="nfo1401"></div>' );
+		root.append( '<div id="'+m_renderer_id+'"></div>' );
+		root.append( '<div id="dbg1401"></div>' );
+		// save references
+		SCREEN.Main 	= $( '#'+m_renderer_id );
+		SCREEN.Info 	= $( '#nfo1401' );
+		SCREEN.Debug 	= $( '#dbg1401' );
+		// sub areas
+		SCREEN.Main.append( '<div id="renderer-overlay"></div>' );
+		SCREEN.Overlay 	= $( '#renderer-overlay' );
+
+		// make basic CSS rules
+		SCREEN.Main.css('position','relative');
+		SCREEN.Overlay.css('position','absolute');
+
+	});
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	Call during CONSTRUCT phase, so INITIALIZE has had time to run
+/*/	SCREEN.CreateLayout = function ( cfg ) {
+		if (!m_root) {
+			throw "SCREEN.Configure() called before Connect phase complete";
+		}
+		// check parameters
+		u_NormalizeConfig( cfg );
+		// add 'attachTo' parameter for RENDERER 
+		cfg.attachId = m_renderer_id;
+		// save configuration for later adjustment
+		m_cfg = cfg;
+
+		// special case for fluid
+		if (cfg.mode===VIEWPORT.TYPE.MODE_FLUID) {
+			var dim = u_GetBrowserDimensions();
+			cfg.renderWidth 	= dim.boxWidth;
+			cfg.renderHeight 	= dim.boxHeight;
+			cfg.worldUnits  	= Math.min(dim.boxWidth,dim.boxHeight);
+		}
+		// Start renderer
+		RENDERER.Initialize ( cfg );
+
+		// dispatch correct display mode
+		switch (cfg.mode) {
+			case VIEWPORT.TYPE.MODE_FIXED:
+				SCREEN.SetFixedLayout ( cfg );
+				break;
+			case VIEWPORT.TYPE.MODE_SCALED:
+				SCREEN.SetScaledLayout ( cfg );
+				break;
+			case VIEWPORT.TYPE.MODE_FLUID:
+				SCREEN.SetFluidLayout ( cfg );
+				break;
+			default:
+				throw "mode "+cfg.mode+" not implemented";
+		}
+
+		// size the width of the debug window
+		SCREEN.Debug.css('width',cfg.renderWidth);
+		// debug.js defines window.DBG_Out() which writes to #debug
+
+		// start renderer refresh
+		RENDERER.AutoRender();
+
+	}; 
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	SCREEN.SetFixedLayout = function ( cfg ) {
+		console.log("SCREEN: setting fixed layout");
+		u_SetAbsoluteSize( SCREEN.Overlay, cfg );
+};
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	SCREEN.SetScaledLayout = function ( cfg ) {
+		console.log("SCREEN: setting scaled layout");
+		// resize viewport on browser resize after 250ms
+		$(window).resize(function () {
+			clearTimeout(m_resize_timer);
+			m_resize_timer = setTimeout(u_ScaleRendererToFit,250);
+		});
+		u_ScaleRendererToFit();
+	};
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	function u_ScaleRendererToFit () {
+		var dim = u_GetBrowserDimensions();
+		var canvas = $(VIEWPORT.WebGLCanvas());
+		canvas.css('width',dim.scaledWidth);
+		canvas.css('height',dim.scaledHeight);
+		SCREEN.Overlay.css('width',dim.scaledWidth);
+		SCREEN.Overlay.css('height',dim.scaledHeight);
+	}
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	SCREEN.SetFluidLayout = function ( cfg ) {
+		console.log("SCREEN: setting fluid layout");
+		// resize viewport on browser resize after 250ms
+		$(window).resize(function () {
+			clearTimeout(m_resize_timer);
+			m_resize_timer = setTimeout(u_SizeRendererToFit,250);
+		});
+		u_SizeRendererToFit();
+	};
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	function u_SizeRendererToFit () {
+		var dim = u_GetBrowserDimensions();
+		SYS1401.glSize(dim.boxWidth, dim.boxHeight);
+		var hh = Math.floor(dim.boxHeight / 2);
+		var ww = Math.floor(dim.boxWidth / 2);
+		var cam = SYS1401.CAMWORLD;
+		if (cam instanceof THREE.OrthographicCamera) {
+			cam.top 	= +hh;
+			cam.bottom 	= -hh;
+			cam.left 	= -ww;
+			cam.right 	= +ww;
+		}
+		if (cam instanceof THREE.PerspectiveCamera) {
+			cam.aspect = dim.boxWidth/dim.boxHeight;
+		}
+		cam.updateProjectionMatrix();
+	}
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	function u_GetBrowserDimensions () {
+		// get dimensions of the viewable area (no scrolling)
+		var screenHeight 	= $(window).height();
+		var displayWidth 	= $(document).width();
+		var displayHeight 	= screenHeight - m_root.offset().top;
+
+		// take any space added to the #display container saved in m_root
+		var insetWidth = parseInt(m_root.css('margin-left'))+parseInt(m_root.css('margin-right'));
+		insetWidth += parseInt(m_root.css('padding-left'))+parseInt(m_root.css('padding-right'));
+		displayWidth = displayWidth - insetWidth;
+		var insetHeight = parseInt(m_root.css('margin-top'))+parseInt(m_root.css('margin-bottom'));
+		insetHeight += parseInt(m_root.css('padding-top'))+parseInt(m_root.css('padding-bottom'));
+		displayHeight = displayHeight - insetHeight;
+
+		// calculate max size to fit current renderer
+		var scaledWidth, 
+			scaledHeight, 
+			multiplier;
+
+		var aspect = m_cfg.renderWidth / m_cfg.renderHeight;
+		multiplier = Math.min(
+			displayWidth / m_cfg.renderWidth,
+			displayHeight / m_cfg.renderHeight
+		);
+		scaledHeight 	= Math.floor(m_cfg.renderHeight * multiplier);
+		scaledWidth		= scaledHeight * aspect;
+
+		return {
+			visWidth 		: displayWidth,		// client area
+			visHeight 		: screenHeight,
+			boxWidth 		: displayWidth,		// without nav
+			boxHeight 		: displayHeight,
+			scaledWidth 	: scaledWidth,		// canvas scaled
+			scaledHeight 	: scaledHeight
+		};
+	}
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	set position absolute to cfg dimensions
+/*/	function u_SetAbsoluteSize ( jsel, cfg ) {
+		jsel.css('width',cfg.renderWidth);
+		jsel.css('height',cfg.renderHeight);
+		jsel.css('position','absolute');
+	}
+
+///////////////////////////////////////////////////////////////////////////////
+/** SCREEN API ***************************************************************/
+
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Utility function to hide scrollbars on the body
+/*/	SCREEN.HideScrollbars = function () {
+		$('body').css('overflow','hidden');
+	};
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	SCREEN.AddRow = function ( id, cls, parent ) {
+		id = (id) ? 'id="'+id+'" ' : '';
+		cls = 'class="row '+ ((cls)?cls:'')+ '" ';
+		parent = parent || SCREEN.Overlay;
+		if (!parent) throw "SCREEN.AddRow() after init phase!";
+		var html = '<div '+id+cls+'></div>';
+		var row = $(html);
+		parent.append(row);
+		return row;
+	};
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	Add a button to default area. Returns jQuery object created button
+/*/	SCREEN.AddButton = function ( id, label, parent ) {
+		if (!id) throw "arg1 must be a unique string";
+		label = label || 'Button';
+		parent = parent || SCREEN.Overlay;
+		if (!parent) throw "SCREEN.AddButton() after init phase!";
+		var html = '<button id="'+id+'" class="btn">'+label+'</button>';
+		var jbtn = $(html);
+		parent.append(jbtn);
+		return jbtn;
+	};
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** UTILITY FUNCTIONS ********************************************************/
+///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	function u_NormalizeConfig( cfg ) {
+		cfg = cfg || {};
+		// check for legal modes
+		switch (cfg.mode) {
+			case VIEWPORT.TYPE.MODE_FIXED:
+			case VIEWPORT.TYPE.MODE_SCALED:
+			case VIEWPORT.TYPE.MODE_FLUID:
+				break;
+			default:
+				throw "error: "+cfg.mode+" is not a valid mode";
+		}
+		// process remaining parameters
+		cfg.renderWidth 	= cfg.renderWidth || 512;
+		cfg.renderHeight 	= cfg.renderHeight || 512;
+		var minWorldUnits 	= Math.min(cfg.renderWidth, cfg.renderHeight);
+		cfg.worldUnits 		= cfg.worldUnits || minWorldUnits;
+		return cfg;
+	}
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** RETURN MODULE ************************************************************/
+	return SCREEN;
+
+});

--- a/build/assets/modules/1401/system/screen.js
+++ b/build/assets/modules/1401/system/screen.js
@@ -69,9 +69,11 @@ define ( [
 			console.warn("SCREEN requires div #"+id,"element");
 			return;
 		} 
-		console.info("SCREEN CONNECT: appending to div#",id);
 		// define main areas
 		m_root = root = $(root);
+		if (m_root.children().length) {
+			console.warn('SCREEN is erasing existing children of div#'+id);
+		}
 		root.empty();
 		root.append( '<div id="nfo1401"></div>' );
 		root.append( '<div id="'+m_renderer_id+'"></div>' );
@@ -110,7 +112,7 @@ define ( [
 		u_NormalizeConfig( cfg );
 
 		// info
-		console.info('SCREEN.CreateLayout is creating',cfg.mode,'layout');
+		console.info('SCREEN is setting-up',cfg.mode,'layout');
 
 		// add 'attachTo' parameter for RENDERER 
 		cfg.attachId = m_renderer_id;


### PR DESCRIPTION
Rather than rely on finicky HTML/CSS to set-up the renderer within a browser window, the new SCREEN module provides a simpler method to do so. Instead of calling RENDERER directly, use SCREEN.
``` js
var cfg = {
  mode      : 'scaled',   // layout mode
  renderWidth   : 768,    // width of render viewport
  renderHeight  : 768,    // height of render viewport
  worldUnits    : 768     //  # world units visible in viewport
};
SCREEN.CreateLayout( cfg );
SCREEN.SetInfo('<h4>PlanTitle</h4><p>Starter tempalte</p>');
SCREEN.SetDisplayMargin(20);
```
There are three types of layout: 
* `fixed` draws the viewport as-defined 1:1 in the upper left of the containing div
* `scaled` scales the viewport as-defined to fit completely within the containing div
* `fluid` resizes the viewport to fit within the available space of the containing div
The SCREEN module also handles resizing of all these modes.

Additionally, the DEBUG and INFO divs are created by SCREEN. You can set the contents of the INFO window at the top using `SCREEN.SetInfo()`, and you can write to the on-screen debug panel using `DEBUG.Out()`. However, these divs are only visible in `fixed` layout mode. 