### PR TITLE
Resolve crashes and livereload conflicts in gulpfile and 1401 server

### DIFF
--- a/build/assets/modules/1401-games/demo/game-run.js
+++ b/build/assets/modules/1401-games/demo/game-run.js
@@ -93,7 +93,7 @@ define ([
 		// instead of initializing renderer directly,
 		// use SCREEN which will initialize it for us
 		var cfg = {
-			mode 			: 'fluid',		// layout mode
+			mode 			: 'fluid',		// 'fixed', 'scaled', or 'fluid'
 			renderWidth 	: 768,			// width of viewport
 			renderHeight 	: 768,			// height of viewport
 			worldUnits 		: 768			// world units visible in viewport

--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -17,14 +17,30 @@
 	var runseq      = require('run-sequence');
 	var argv  		= require('yargs').argv;
 
+
 	var BOWER       = 'bower_components/';
 	var PUBLIC      = 'public/';
 	var VENDOR      = PUBLIC + 'modules/vendor/';
 	var MODULES     = PUBLIC + 'modules/';
 	var ASSETS      = 'assets/';
 
-	var server1401  = require('./server/1401.js');
-	var serverInstance;
+	// for managing the 1401 server node process
+	var fork = require('child_process').fork;
+	var server1401;
+
+
+///	PROCESS CONTROL ///////////////////////////////////////////////////////////
+/*/	on control-c, we need to stop the 1401 web server also
+/*/	process.on('SIGINT',function() {
+		if (server1401) {
+			server1401.kill();
+			console.log('\n1401 express server terminated');
+		}
+		console.log('exiting process...');
+		process.exit();
+	});
+
+
 
 ///	GULP TASKS ////////////////////////////////////////////////////////////////
 ///	
@@ -160,11 +176,8 @@
 /*/ Start up the server module, passing yargs.argv object, which will be
 	used as a configuration object by startServer
 /*/	function runServer() {
-		serverInstance = server1401.startServer( argv );
-		server1401.startLiveReload();
-
-		// if you need the express app instance:
-		// var app = server1401.getExpressApp();
+		// fork the 1401 process
+		server1401 = fork('./server/1401.js');
 
 		// if changing watch path, make sure to change copy paths in tasks
 		gulp.watch(ASSETS+'modules/**', function ( event ) {

--- a/build/server/1401-server.js
+++ b/build/server/1401-server.js
@@ -1,0 +1,158 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+	1401-server.js is imported by 1401.js as a module.
+
+	This server code is based on the Mimosa server.js, but is adapted for use
+	with our new Gulp workflow.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+	// import libraries
+	var express 		= require('express');
+	var bodyParser 		= require('body-parser');
+	var engines 		= require('consolidate');
+	var compression 	= require('compression');
+	var favicon 		= require('serve-favicon');
+	var cookieParser 	= require('cookie-parser');
+	var errorHandler 	= require('errorhandler');
+	var ip 				= require('ip');
+
+	// allocate 
+	var tinylr;			// set by startLiveReload
+	var app; 			// set by startServer
+	var server;			// set by startServer
+	var config; 		// save configuration object from startServer()
+
+	// server init hook
+	var sv_init_hook;	// if set, then will call before app.listen()
+
+
+///////////////////////////////////////////////////////////////////////////////
+
+	var EXPRESS_PORT 	= 3000;
+	var VIEWS_PATH 		= __dirname+'/views';
+	var VIEWS_EXT 		= 'hbs';
+	var VIEWS_COMPILER 	= 'handlebars';
+	var COMPILED_DIR 	= __dirname+'/../public';
+	var BP 				= '          ';
+	var INFOP 			= '         >';
+	var DP 				= '----------';
+	var NP				= '         !';
+	var FP				= '         *';
+	var ERRP			= '       ERR';
+
+///////////////////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ config is an object. It will be created if it doesn't exist. This is called
+	by gulpfile.js's runServer() function, which passes a yargs.argv object that
+	should be compatible with this code.
+/*/	function startServer ( cfg ) {
+
+		// initialize config from either passed value or as new object
+		// save as module-wide object
+		config = cfg || {};
+		// force optimize false always to use requirejs
+		config.isOptimize = false; // was config.isOptimize!==undefined;
+		config.port = config.port || EXPRESS_PORT;
+
+		startExpress();
+
+	}
+
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ continuing from startServer, startExpress is potentially called async
+	as a callback on liveReload event when the old server is closed.
+/*/	function startExpress () {
+		// instantiate express app
+		app = express();
+
+		// setup views and port
+		app.set('views', VIEWS_PATH);
+		app.engine(VIEWS_EXT, engines[VIEWS_COMPILER]);
+		app.set('view engine', VIEWS_EXT);
+		app.set('port', config.port || 3000);
+
+		// middleware declarations
+		app.use(compression());
+		// uncomment and point path at favicon if you have one
+		// app.use(favicon("path to fav icon"));
+		app.use(bodyParser.json());
+		app.use(bodyParser.urlencoded({extended: true}));
+		app.use(cookieParser());
+
+		// enable node error serving in development environment
+		if (app.get('env') === 'development') {
+		  app.use(errorHandler());
+		}
+
+		// serve static files from compiledDir
+		app.use(express.static(COMPILED_DIR));
+
+		// routes are relative to compiledDir
+		var router = express.Router();
+		router.get('/', function(req, res) {
+			var fullURL = req.protocol+"://";
+			fullURL += req.hostname+':'+config.liveReloadPort;
+			fullURL += '/livereload.js';
+			res.render('index', {
+				reload: 	config.liveReload,
+				optimize:  	config.isOptimize,
+				reloadjs: 	fullURL
+			});
+		});
+		app.use('/', router);
+
+		// for startup that need to do further configuration
+		// to the express app, this hook is provided
+		if (typeof (sv_init_hook)==='function') {
+			sv_init_hook( app );
+		}
+
+		// start it up
+		server = app.listen(app.get('port'), function() {
+			console.log(DP,'VISIT ONE OF THESE URLS in CHROME WEB BROWSER',DP);
+			console.log(BP,'LOCAL ... http://localhost:'+app.get('port'));
+			console.log(BP,'LAN ..... http://'+ip.address()+':'+app.get('port'));
+		});
+
+		// server is an instance of http.Server
+		return server;
+
+	} // startServer 
+
+
+
+
+///	PROPERTY ACCESS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Return the Express App instance
+/*/ function getExpressApp() {
+		if (!app) 
+			console.log(ERRP,'server1401/getExpressApp: app is not yet defined');
+		return app;
+	}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/ Return the HTTP Server instance
+/*/ function getServer () {
+		if (!server) 
+			console.log(ERRP,'server1401/getServer: server is not yet defined');
+		return server;
+	}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/*/	The passed hook will be called with the Express app instance BEFORE 
+	app.listen() is executed. Call before startServer()
+/*/	function setServerInitHook ( hook ) {
+		if (typeof hook==='function') {
+			sv_init_hook = hook;
+		} else {
+			throw new Error('arg must be function');
+		}
+	}
+
+
+///////////////////////////////////////////////////////////////////////////////
+/** RETURN MODULE DEFINITION *************************************************/
+	module.exports.startServer			= startServer;
+	module.exports.getServer			= getServer;
+	module.exports.getApp				= getExpressApp;
+	module.exports.setServerInitHook	= setServerInitHook;

--- a/build/server/1401-server.js
+++ b/build/server/1401-server.js
@@ -55,8 +55,8 @@
 		config.isOptimize = false; // was config.isOptimize!==undefined;
 		config.port = config.port || EXPRESS_PORT;
 
+		// actually start the web server
 		startExpress();
-
 	}
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/build/server/1401.js
+++ b/build/server/1401.js
@@ -197,11 +197,8 @@
 		return server;
 	}
 
+/*/ START /*/
 
-///	EXPORT ////////////////////////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-	module.exports.startServer 		= startServer;
-	module.exports.startLiveReload 	= startLiveReload;
-	module.exports.notifyLiveReload = notifyLiveReload;
-	module.exports.getServer 		= getServer;
-	module.exports.getExpressApp 	= getExpressApp;
+	console.log('child 1401 process fork');
+	startServer();
+	startLiveReload();

--- a/build/server/1401.js
+++ b/build/server/1401.js
@@ -68,15 +68,27 @@
 		// otherwise, close the server and invoke startExpress()
 		// when the server has completely closed to avoid
 		// EADDRESSINUSE errors
-		app = null;
-		server.close( startExpress ); // startExpress is a callback
+		app = 0;
+		console.log('--- dbg: waiting for server to close...');
+		server.close(function(){
+			console.log('--- dbg: ...server closed, restarting server');
+		 	 startExpress();
+		 }); // startExpress is a callback
+
+		/** this might be returning some invalid reference **/
 	}
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /*/ continuing from startServer, startExpress is potentially called async
 	as a callback on liveReload event when the old server is closed.
 /*/	function startExpress () {
-
+		if (app===0) {
+			console.log('*** dbg: startExpress called async from server.close');
+			// was this missing?
+			server = null;
+		} else {
+			console.log('*** dbg: startExpress first time call');
+		}
 		// instantiate express app
 		app = express();
 
@@ -140,6 +152,7 @@
 /*/ Called by gulpfile.js to enable livereload for browser-served files. Note
 	that livereload does NOT restart the Node server.
 /*/	function startLiveReload() {
+		console.log('*** dbg: start livereload');
 		tinylr = require('tiny-lr')();
 		tinylr.listen( config.liveReloadPort, function () {
 			console.log(DP,'Live reload of assets is enabled, (port',
@@ -159,7 +172,12 @@
 			}
 		});
 		console.log(FP,'reload:',fileName);
-		startServer(config);
+
+		// DEBUG TEST SEP-01-2016
+		// commented out startServer because it doesn't work and might be
+		// causing the issues with restarting: see repo issue #6
+		// startServer(config);
+
 	} // notifyLiveReload
 
 

--- a/build/server/1401.js
+++ b/build/server/1401.js
@@ -1,204 +1,26 @@
 /*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
 
-	1401.js is imported by gulpfile.js as a module, executing in the context
-	of the node.js environment. 
+	1401.js is the 'server startup' code, called directly from the gulpfile
+	in runServer(). It is invoked in a separate node instance, so it can be
+	killed and restarted independently of the gulp build process.
 
-	This server code is based on the Mimosa server.js, but is adapted for use
-	with our new Gulp workflow.
+	For unmodified 1401A1 instances, you won't have to change this unless
+	you want to add new features.
 
+	To add new features, create your own version of 1401.js (name 
+	it something else) that does a call to server.setServerInitHook( hook )
+	BEFORE calling startServer(). The hook function will recieve an instance
+	of the express app, which can be modified BEFORE app.listen() is invoked.
+	You can add your own routes, etc, then.
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
-	// import libraries
-	var express 		= require('express');
-	var bodyParser 		= require('body-parser');
-	var engines 		= require('consolidate');
-	var compression 	= require('compression');
-	var favicon 		= require('serve-favicon');
-	var cookieParser 	= require('cookie-parser');
-	var errorHandler 	= require('errorhandler');
-	var ip 				= require('ip');
-
-	// allocate 
-	var tinylr;	// set by startLiveReload
-	var app; 	// set by startServer
-	var server;	// set by startServer
-	var config; // save configuration object from startServer()
-
+	var server = require('./1401-server');
 
 ///////////////////////////////////////////////////////////////////////////////
 
-	var LIVERELOAD_PORT = 35729;
-	var EXPRESS_PORT 	= 3000;
-	var VIEWS_PATH 		= __dirname+'/views';
-	var VIEWS_EXT 		= 'hbs';
-	var VIEWS_COMPILER 	= 'handlebars';
-	var COMPILED_DIR 	= __dirname+'/../public';
-	var BP 				= '          ';
-	var INFOP 			= '         >';
-	var DP 				= '----------';
-	var NP				= '         !';
-	var FP				= '         *';
-	var ERRP			= '       ERR';
+	server.startServer();
 
 ///////////////////////////////////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ config is an object. It will be created if it doesn't exist. This is called
-	by gulpfile.js's runServer() function, which passes a yargs.argv object that
-	should be compatible with this code.
-/*/	function startServer ( yargsv ) {
-
-		// initialize config from either passed value or as new object
-		// save as module-wide object
-		config = yargsv || {};
-		// set default values if not defined
-		config.liveReload = config.liveReload || {};
-		config.liveReload.enabled = config.liveReload.enabled || true;
-		// force optimize false always to use requirejs
-		config.isOptimize = false; // was config.isOptimize!==undefined;
-		config.liveReloadPort = config.liveport || LIVERELOAD_PORT;
-		config.port = config.port || EXPRESS_PORT;
-		config.ServerInitHook = config.ServerInitHook || null;
-
-		// if the server is not restarting, then just return
-		// the express app instance to caller
-		var server_restart = (server) ? true : false;
-		if (!server_restart) return startExpress();
-
-		// otherwise, close the server and invoke startExpress()
-		// when the server has completely closed to avoid
-		// EADDRESSINUSE errors
-		app = 0;
-		console.log('--- dbg: waiting for server to close...');
-		server.close(function(){
-			console.log('--- dbg: ...server closed, restarting server');
-		 	 startExpress();
-		 }); // startExpress is a callback
-
-		/** this might be returning some invalid reference **/
-	}
-
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ continuing from startServer, startExpress is potentially called async
-	as a callback on liveReload event when the old server is closed.
-/*/	function startExpress () {
-		if (app===0) {
-			console.log('*** dbg: startExpress called async from server.close');
-			// was this missing?
-			server = null;
-		} else {
-			console.log('*** dbg: startExpress first time call');
-		}
-		// instantiate express app
-		app = express();
-
-		// setup views and port
-		app.set('views', VIEWS_PATH);
-		app.engine(VIEWS_EXT, engines[VIEWS_COMPILER]);
-		app.set('view engine', VIEWS_EXT);
-		app.set('port', config.port || 3000);
-
-		// middleware declarations
-		app.use(compression());
-		// uncomment and point path at favicon if you have one
-		// app.use(favicon("path to fav icon"));
-		app.use(bodyParser.json());
-		app.use(bodyParser.urlencoded({extended: true}));
-		app.use(cookieParser());
-
-		// enable node error serving in development environment
-		if (app.get('env') === 'development') {
-		  app.use(errorHandler());
-		}
-
-		// serve static files from compiledDir
-		app.use(express.static(COMPILED_DIR));
-
-		// routes are relative to compiledDir
-		var router = express.Router();
-		router.get('/', function(req, res) {
-			var fullURL = req.protocol+"://";
-			fullURL += req.hostname+':'+config.liveReloadPort;
-			fullURL += '/livereload.js';
-			res.render('index', {
-				reload: 	config.liveReload,
-				optimize:  	config.isOptimize,
-				reloadjs: 	fullURL
-			});
-		});
-		app.use('/', router);
-
-		// for gulpfiles that need to do further configuration
-		// to the express app, this hook is provided
-		if (typeof (config.ServerInitHook)==='function') {
-			config.ServerInitHook( app );
-		}
-
-		// start it up
-		server = app.listen(app.get('port'), function() {
-			console.log(DP,'VISIT ONE OF THESE URLS in CHROME WEB BROWSER',DP);
-			console.log(BP,'LOCAL ... http://localhost:'+app.get('port'));
-			console.log(BP,'LAN ..... http://'+ip.address()+':'+app.get('port'));
-		});
-
-		// server is an instance of http.Server
-		return server;
-
-	} // startServer 
-
-
-///////////////////////////////////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Called by gulpfile.js to enable livereload for browser-served files. Note
-	that livereload does NOT restart the Node server.
-/*/	function startLiveReload() {
-		console.log('*** dbg: start livereload');
-		tinylr = require('tiny-lr')();
-		tinylr.listen( config.liveReloadPort, function () {
-			console.log(DP,'Live reload of assets is enabled, (port',
-				config.liveReloadPort+')',DP);
-		});
-	} // startLiveReload
-
-
-///////////////////////////////////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Called by gulpfile when a livereload event has been detected.
-/*/	function notifyLiveReload (event) {
-		var fileName = require('path').relative(__dirname, event.path);
-		tinylr.changed({
-			body: {
-				files: [fileName]
-			}
-		});
-		console.log(FP,'reload:',fileName);
-
-		// DEBUG TEST SEP-01-2016
-		// commented out startServer because it doesn't work and might be
-		// causing the issues with restarting: see repo issue #6
-		// startServer(config);
-
-	} // notifyLiveReload
-
-
-///	PROPERTY ACCESS ////////////////////////////////////////////////////////////
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Return the Express App instance
-/*/ function getExpressApp() {
-		if (!app) 
-			console.log(ERRP,'server1401/getExpressApp: app is not yet defined');
-		return app;
-	}
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ Return the HTTP Server instance
-/*/ function getServer () {
-		if (!server) 
-			console.log(ERRP,'server1401/getServer: server is not yet defined');
-		return server;
-	}
-
-/*/ START /*/
-
-	console.log('child 1401 process fork');
-	startServer();
-	startLiveReload();
+/** RETURN MODULE DEFINITION *************************************************/
+	module.exports.setServerInitHook = server.setServerInitHook;


### PR DESCRIPTION
As reported in issue #6, the old server code did not properly close and restart the Express server processes gracefully because this is actually a somewhat tricky thing to do. It was possible for multiple live-reload requests to pile up while the servers were closing/restarting, firing all at once when they timed-out and creating a "EADDRINUSE" error. 

The server rewrite takes a different approach, spawning the 1401 server as a separate NodeJS process that can be more easily killed and restarted. Livereload functionality has been moved back to the gulpfile, and has been extended to handle changes to the server files as well as client browser files. In the case a server file is changed, the server process is shut down and restarted. 

Additionally, this pull request supports a new `gulp debug` option, which will launch the project using `node-debug`. You must `npm install -g node-inspector` for this option to work correctly.