### PR TITLE
RENDERER now supports 32-bit PNG as well as JPEG Screen Capturing

### DIFF
--- a/build/assets/modules/1401/system/renderer.js
+++ b/build/assets/modules/1401/system/renderer.js
@@ -31,7 +31,7 @@ define ([
 
 	var CAPTURE_SCREEN = false;				// for screen capturing
 	var CAPTURE_CALLBACK = null;
-	var CAPTURE_TYPE = 'image/png';
+	var CAPTURE_TYPE = 'image/jpeg';		// default image save type
 
 	var _prerender = [];					// registered outside renderhandler
 	var _postrender = [];					// registered outside renderhandler
@@ -112,7 +112,7 @@ define ([
 		if (typeof callback==='function') {
 			CAPTURE_CALLBACK = callback;
 		} else {
-			throw new Error('CaptureJPEG requires a callback function to receive jpg base64 data');
+			throw new Error('CaptureJPEG requires a callback function to receive base64 JPEG data');
 		}
 	};
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -132,7 +132,7 @@ define ([
 		if (typeof callback==='function') {
 			CAPTURE_CALLBACK = callback;
 		} else {
-			throw new Error('CaptureJPEG requires a callback function to receive jpg base64 data');
+			throw new Error('CaptureScreen requires a callback function to receive img base64 data, plus a imgtype specifier');
 		}
 	};
 


### PR DESCRIPTION
The old `RENDERER.CaptureJPEG()` method accepted just a callback function which received JPEG-formatted image data encoded in base64. 

The new `RENDERER.CaptureScreen()` methods accepts and additional `type` parameter that can be either `image/jpeg` (the default) or `image/png`. The callback function receives the `type` as well now, so you can determine what kind of data you just received. You can continue to use the `CaptureJPEG()` function if you don't need to save the alpha channel from the framebuffer.